### PR TITLE
Miscellaneous fixes

### DIFF
--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -773,22 +773,25 @@ class Block(Node):
 
 
 class BlockLabel(Node):
-    _fields_ = ['name', 'args']
+    _fields_ = ['name', 'arg_ids', 'arg_types']
 
     def __init__(self, node: Token = None, **fields):
         self.name = node[0]
         if len(node) > 1:
-            self.args = node[1]
+            arg_id_and_types = [arg.children for arg in node[1][0]]
+            self.arg_ids, self.arg_types = zip(*arg_id_and_types)
         else:
-            self.args = []
+            self.arg_ids = []
+            self.arg_types = []
 
         super().__init__(None, **fields)
 
     def dump(self, indent: int = 0) -> str:
         result = dump_or_value(self.name, indent)
-        if self.args:
+        if self.arg_ids:
             result += ' (%s)' % (', '.join(
-                dump_or_value(arg, indent) for arg in self.args))
+                f'{dump_or_value(id_, indent)}: {dump_or_value(type_, indent)}'
+                for id_, type_ in zip(self.arg_ids, self.arg_types)))
         result += ':\n'
         return result
 

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -248,9 +248,10 @@ class RankedMemRefType(Type):
         super().__init__(None, **fields)
 
     def dump(self, indent: int = 0) -> str:
-        result = 'memref<%s' % ('x'.join(
-            t.dump(indent)
-            for t in self.dimensions) + 'x' + self.element_type.dump(indent))
+        result = 'memref<%s' % ('x'.join(t.dump(indent)
+                                         for t in self.dimensions)
+                                + ('x' if self.dimensions else '')
+                                + self.element_type.dump(indent))
         if self.layout is not None:
             result += ', ' + self.layout.dump(indent)
         if self.space is not None:
@@ -314,7 +315,7 @@ class StridedLayout(Node):
     _fields_ = ['offset', 'strides']
 
     def dump(self, indent: int = 0) -> str:
-        return 'offset: %s, strides: %s' % (dump_or_value(
+        return 'offset: %s, strides: [%s]' % (dump_or_value(
             self.offset, indent), dump_or_value(self.strides, indent))
 
 
@@ -523,7 +524,7 @@ class Operation(Node):
         super().__init__(None, **fields)
 
     def dump(self, indent: int = 0) -> str:
-        result = ''
+        result = indent * '  '
         if self.result_list:
             result += '%s = ' % (', '.join(
                 dump_or_value(r, indent) for r in self.result_list))
@@ -765,8 +766,9 @@ class Block(Node):
         result = ''
         if self.label:
             result += indent * '  ' + self.label.dump(indent)
+            indent += 1
         result += '\n'.join(
-            indent * '  ' + stmt.dump(indent) for stmt in self.body)
+            stmt.dump(indent) for stmt in self.body)
         return result
 
 

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -685,7 +685,8 @@ class Function(Node):
             self.args = []
         if (len(signature) > index
                 and signature[index].data == 'function_result_list'):
-            self.result_types = signature[index].children
+            # first child contains all the result types
+            self.result_types = signature[index].children[0]
             index += 1
         else:
             self.result_types = []
@@ -715,8 +716,8 @@ class Function(Node):
         result += '(%s)' % ', '.join(
             dump_or_value(arg, indent) for arg in self.args)
         if self.result_types:
-            if len(self.result_types) == 1:
-                result += ' -> ' + dump_or_value(self.result_types[0], indent)
+            if not isinstance(self.result_types, list):
+                result += ' -> ' + dump_or_value(self.result_types, indent)
             else:
                 result += ' -> (%s)' % ', '.join(
                     dump_or_value(res, indent) for res in self.result_types)

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -931,7 +931,7 @@ class AffineMap(Node):
     _fields_ = ['dims_and_symbols', 'map']
 
     def dump(self, indent: int = 0) -> str:
-        return '%s -> %s' % (dump_or_value(self.dims_and_symbols, indent),
+        return 'affine_map<%s -> %s>' % (dump_or_value(self.dims_and_symbols, indent),
                              dump_or_value(self.map, indent))
 
 

--- a/mlir/dialects/standard.py
+++ b/mlir/dialects/standard.py
@@ -61,6 +61,7 @@ class ExpOperation(UnaryOperation): _opname_ = 'exp'
 class NegfOperation(UnaryOperation): _opname_ = 'negf'
 class TanhOperation(UnaryOperation): _opname_ = 'tanh'
 class CopysignOperation(UnaryOperation): _opname_ = 'copysign'
+class SIToFPOperation(UnaryOperation): _opname_ = 'sitofp'
 
 # Arithmetic Operations
 class AddiOperation(BinaryOperation): _opname_ = 'addi'
@@ -72,6 +73,7 @@ class RemisOperation(BinaryOperation): _opname_ = 'remis'
 class RemiuOperation(BinaryOperation): _opname_ = 'remiu'
 class DivfOperation(BinaryOperation): _opname_ = 'divf'
 class MulfOperation(BinaryOperation): _opname_ = 'mulf'
+class MulIOperation(BinaryOperation): _opname_ = 'muli'
 class SubiOperation(BinaryOperation): _opname_ = 'subi'
 class SubfOperation(BinaryOperation): _opname_ = 'subf'
 class OrOperation(BinaryOperation): _opname_ = 'or'
@@ -84,6 +86,8 @@ class CmpfOperation(DialectOp):
     _syntax_ = 'cmpf {comptype.string_literal} , {operand_a.ssa_id} , {operand_b.ssa_id} : {type.type}'
 class ConstantOperation(DialectOp):
     _syntax_ = 'constant {value.attribute_value} : {type.type}'
+class IndexCastOperation(DialectOp):
+    _syntax_ = 'index_cast {arg.ssa_use} : {src_type.type} to {dst_type.type}'
 class MemrefCastOperation(DialectOp):
     _syntax_ = 'memref_cast {arg.ssa_use} : {src_type.type} to {dst_type.type}'
 class TensorCastOperation(DialectOp):
@@ -92,6 +96,9 @@ class SelectOperation(DialectOp):
     _syntax_ = 'select {cond.ssa_use} , {arg_true.ssa_use} , {arg_false.ssa_use} : {type.type}'
 class SubviewOperation(DialectOp):
     _syntax_ = 'subview {operand.ssa_use} [ {offsets.ssa_use_list} ] [ {sizes.ssa_use_list} ] [ {strides.ssa_use_list} ] : {src_type.type} to {dst_type.type}'
+class ViewOperation(DialectOp):
+    _syntax_ = ['view {operand.ssa_use} [ {offset.ssa_use} ] [ {sizes.ssa_use_list} ] : {src_type.type} to {dst_type.type}',
+                'view {operand.ssa_use} [ {offset.ssa_use} ] [  ] : {src_type.type} to {dst_type.type}']
 
 # Inspect current module to get all classes defined above
 standard = Dialect('standard', ops=[m[1] for m in inspect.getmembers(

--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -251,7 +251,7 @@ affine_constraint : affine_expr ">=" "0"    -> affine_constraint_ge
                   | affine_expr "==" "0"    -> affine_constraint_eq
 affine_constraint_conjunction : affine_constraint ("," affine_constraint)*
 
-affine_map_inline      : dim_and_symbol_id_lists "->" multi_dim_affine_expr
+affine_map_inline      : "affine_map" "<" dim_and_symbol_id_lists "->" multi_dim_affine_expr ">"
 semi_affine_map_inline : dim_and_symbol_id_lists "->" multi_dim_semi_affine_expr
 integer_set_inline     : dim_and_symbol_id_lists ":" "(" affine_constraint_conjunction? ")"
 
@@ -259,6 +259,8 @@ integer_set_inline     : dim_and_symbol_id_lists ":" "(" affine_constraint_conju
 affine_map      : map_or_set_id | affine_map_inline
 semi_affine_map : map_or_set_id | semi_affine_map_inline
 integer_set     : map_or_set_id | integer_set_inline
+
+affine_map_list : affine_map ("," affine_map)*
 
 // ----------------------------------------------------------------------
 // General structure and top-level definitions

--- a/mlir/parser_transformer.py
+++ b/mlir/parser_transformer.py
@@ -202,6 +202,7 @@ class TreeToMlir(Transformer):
     non_function_type = lambda self, value: value[0]
     type = lambda self, value: value[0]
     type_list_parens = lambda self, value: (value[0] if value else [])
+    function_result = lambda self, value: value[0]
     function_result_type = lambda self, value: value[0]
     standard_attribute = lambda self, value: value[0]
     attribute_value = lambda self, value: value[0]
@@ -209,7 +210,7 @@ class TreeToMlir(Transformer):
     attribute_entry = lambda self, value: value[0]
     trailing_type = lambda self, value: value[0]
     trailing_location = lambda self, value: value[0]
-    function_result_list_parens = lambda self, value: value[0]
+    function_result_list_parens = lambda self, value: (value[0] if value else [])
     symbol_or_const = lambda self, value: value[0]
     affine_map = lambda self, value: value[0]
     semi_affine_map = lambda self, value: value[0]

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -127,7 +127,7 @@ def test_affine(parser: Optional[Parser] = None):
 func @empty() {
   affine.for %i = 0 to 10 {
   } {some_attr = true}
-  %0 = affine.min (d0)[s0] -> (1000, d0 + 512, s0) (%arg0)[%arg1]
+  %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 }
 func @valid_symbols(%arg0: index, %arg1: index, %arg2: index) {
   %c0 = constant 1 : index
@@ -156,17 +156,17 @@ func @valid_symbols(%arg0: index, %arg1: index, %arg2: index) {
 
 def test_definitions(parser: Optional[Parser] = None):
     code = '''
-#map0 = (d0, d1) -> (d0, d1)
-#map1 = (d0) -> (d0)
-#map2 = () -> (0)
-#map3 = () -> (10)
-#map4 = (d0, d1, d2) -> (d0, d1 + d2 + 5)
-#map5 = (d0, d1, d2) -> (d0 + d1, d2)
-#map6 = (d0, d1)[s0] -> (d0, d1 + s0 + 7)
-#map7 = (d0, d1)[s0] -> (d0 + s0, d1)
-#map8 = (d0, d1) -> (d0 + d1 + 11)
-#map9 = (d0, d1)[s0] -> (d0, (d1 + s0) mod 9 + 7)
-#map10 = (d0, d1)[s0] -> ((d0 + s0) floordiv 3, d1)
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0) -> (d0)>
+#map2 = affine_map<() -> (0)>
+#map3 = affine_map<() -> (10)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1 + d2 + 5)>
+#map5 = affine_map<(d0, d1, d2) -> (d0 + d1, d2)>
+#map6 = affine_map<(d0, d1)[s0] -> (d0, d1 + s0 + 7)>
+#map7 = affine_map<(d0, d1)[s0] -> (d0 + s0, d1)>
+#map8 = affine_map<(d0, d1) -> (d0 + d1 + 11)>
+#map9 = affine_map<(d0, d1)[s0] -> (d0, (d1 + s0) mod 9 + 7)>
+#map10 = affine_map<(d0, d1)[s0] -> ((d0 + s0) floordiv 3, d1)>
 #samap0 = (d0)[s0] -> (d0 floordiv (s0 + 1))
 #samap1 = (d0)[s0] -> (d0 floordiv s0)
 #samap2 = (d0, d1)[s0, s1] -> (d0*s0 + d1*s1)
@@ -176,9 +176,9 @@ def test_definitions(parser: Optional[Parser] = None):
 #set3 = (d0, d1, d2) : (d0 - d2 * 4 == 0, d0 + d1 * 8 - 9 >= 0, -d0 - d1 * 8 + 11 >= 0)
 #set4 = (d0, d1, d2, d3, d4, d5) : (d0 * 1089234 + d1 * 203472 + 82342 >= 0, d0 * -55 + d1 * 24 + d2 * 238 - d3 * 234 - 9743 >= 0, d0 * -5445 - d1 * 284 + d2 * 23 + d3 * 34 - 5943 >= 0, d0 * -5445 + d1 * 284 + d2 * 238 - d3 * 34 >= 0, d0 * 445 + d1 * 284 + d2 * 238 + d3 * 39 >= 0, d0 * -545 + d1 * 214 + d2 * 218 - d3 * 94 >= 0, d0 * 44 - d1 * 184 - d2 * 231 + d3 * 14 >= 0, d0 * -45 + d1 * 284 + d2 * 138 - d3 * 39 >= 0, d0 * 154 - d1 * 84 + d2 * 238 - d3 * 34 >= 0, d0 * 54 - d1 * 284 - d2 * 223 + d3 * 384 >= 0, d0 * -55 + d1 * 284 + d2 * 23 + d3 * 34 >= 0, d0 * 54 - d1 * 84 + d2 * 28 - d3 * 34 >= 0, d0 * 54 - d1 * 24 - d2 * 23 + d3 * 34 >= 0, d0 * -55 + d1 * 24 + d2 * 23 + d3 * 4 >= 0, d0 * 15 - d1 * 84 + d2 * 238 - d3 * 3 >= 0, d0 * 5 - d1 * 24 - d2 * 223 + d3 * 84 >= 0, d0 * -5 + d1 * 284 + d2 * 23 - d3 * 4 >= 0, d0 * 14 + d2 * 4 + 7234 >= 0, d0 * -174 - d2 * 534 + 9834 >= 0, d0 * 194 - d2 * 954 + 9234 >= 0, d0 * 47 - d2 * 534 + 9734 >= 0, d0 * -194 - d2 * 934 + 984 >= 0, d0 * -947 - d2 * 953 + 234 >= 0, d0 * 184 - d2 * 884 + 884 >= 0, d0 * -174 + d2 * 834 + 234 >= 0, d0 * 844 + d2 * 634 + 9874 >= 0, d2 * -797 - d3 * 79 + 257 >= 0, d0 * 2039 + d2 * 793 - d3 * 99 - d4 * 24 + d5 * 234 >= 0, d2 * 78 - d5 * 788 + 257 >= 0, d3 - (d5 + d0 * 97) floordiv 423 >= 0, ((d0 + (d3 mod 5) floordiv 2342) * 234) mod 2309 + (d0 + d3 * 2038) floordiv 208 >= 0, ((((d0 + d3 * 2300) * 239) floordiv 2342) mod 2309) mod 239423 == 0, d0 + d3 mod 2642 + (((((d3 + d0 * 2) mod 1247) mod 2038) mod 2390) mod 2039) floordiv 55 >= 0)
 #matmul_accesses = [
-  (m, n, k) -> (m, k),
-  (m, n, k) -> (k, n),
-  (m, n, k) -> (m, n)
+  affine_map<(m, n, k) -> (m, k)>,
+  affine_map<(m, n, k) -> (k, n)>,
+  affine_map<(m, n, k) -> (m, n)>
 ]
 #matmul_trait = {
   args_in = 2,


### PR DESCRIPTION
- `affine_map` syntax update
- corrects the handling of function results (roundtrip of functions with >1 results was broken)
- fixes the indentation level handling of the dumped AST
- separates the arg ids and types of inputs to `Block` (roundtrip for blocks with arguments was broken)
- added `std.view`, `std.sitofp`, `std.index_cast`