### PR TITLE
Adds an IR builder

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,8 +7,7 @@ pyMLIR is a Python Interface for the Multi-Level Intermediate Representation (ML
    :maxdepth: 2
 
    custom_dialect
-   source/modules
-	  
+   ref_builder
 
 
 Reference

--- a/doc/ref_builder.rst
+++ b/doc/ref_builder.rst
@@ -1,0 +1,5 @@
+Builder API
+===========
+
+
+.. automodule:: mlir.builder

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -714,7 +714,7 @@ class NamedArgument(Node):
 @dataclass
 class MLIRFile(Node):
     definitions: List["Definition"]
-    module: List[Module]
+    modules: List[Module]
 
     def dump(self, indent: int = 0) -> str:
         result = ''
@@ -724,9 +724,20 @@ class MLIRFile(Node):
 
             result += '\n'
 
-        if self.module:
-            result += dump_or_value(self.module, indent)
+        if self.modules:
+            result += dump_or_value(self.modules, indent)
         return result
+
+    @property
+    def default_module(self) -> Module:
+        """
+        If *self* contains exactly one module returns it, otherwise raises a
+        :class:`ValueError`.
+        """
+        if len(self.modules) != 1:
+            raise ValueError("Can access default_module iff the "
+                             "MLIR file has exactly one module.")
+        return self.modules[0]
 
 
 ##############################################################################

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -734,12 +734,39 @@ class MLIRFile(Node):
 
 
 # Types of affine expressions
+# Contents of single/multi-dimensional (semi-)affine expressions
 class AffineExpr(Node):
-    pass
+    # TODO: Inserts a lot of "AffineParens" that  leading to a generated with high
+    # SNR. Should solve this by strategically placing the parens so that the
+    # precedence isn't violated.
+    def __add__(self, other: Union["AffineExpr", int]):
+        return AffineParens(AffineAdd(operand_a=self, operand_b=other))
+
+    def __sub__(self, other: Union["AffineExpr", int]):
+        return AffineParens(AffineSub(operand_a=self, operand_b=other))
+
+    def __mul__(self, other: int):
+        return AffineParens(AffineMul(operand_a=self, operand_b=other))
+
+    def __neg__(self):
+        return AffineParens(AffineNeg(operand=self))
+
+    def __radd__(self, other: Union["AffineExpr", int]):
+        return AffineParens(AffineAdd(operand_a=other, operand_b=self))
+
+    def __rsub__(self, other: Union["AffineExpr", int]):
+        return AffineParens(AffineSub(operand_a=other, operand_b=self))
+
+    def __rmul__(self, other: int):
+        return AffineParens(AffineMul(operand_a=other, operand_b=self))
 
 
 class SemiAffineExpr(AffineExpr):
-    pass
+    def __floordiv__(self, other: int):
+        return AffineParens(AffineFloorDiv(operand_a=self, operand_b=other))
+
+    def __mod__(self, other: int):
+        return AffineParens(AffineMod(operand_a=self, operand_b=other))
 
 
 @dataclass
@@ -762,7 +789,18 @@ class MultiDimSemiAffineExpr(Node):
         return '(%s)' % dump_or_value(self.dims, indent)
 
 
-# Contents of single/multi-dimensional (semi-)affine expressions
+class AffineSsa(SsaId, AffineExpr):
+    pass
+
+
+@dataclass
+class AffineDimOrSymbol(AffineExpr):
+    value: str
+
+    def dump(self, indent: int = 0) -> str:
+        return self.value
+
+
 @dataclass
 class AffineUnaryOp(AffineExpr):
     operand: AffineExpr

--- a/mlir/builder/__init__.py
+++ b/mlir/builder/__init__.py
@@ -1,0 +1,17 @@
+from .builder import IRBuilder
+from .match import Reads, Writes, Isa, All, And, Or, Not
+
+
+__doc__ = """
+.. currentmodule:: mlir.builder
+
+.. automodule:: mlir.builder.builder
+
+.. automodule:: mlir.builder.match
+"""
+
+
+__all__ = [
+        'IRBuilder',
+
+        'Reads', 'Writes', 'Isa', 'All', 'And', 'Or', 'Not']

--- a/mlir/builder/builder.py
+++ b/mlir/builder/builder.py
@@ -1,0 +1,532 @@
+""" MLIR IR Builder."""
+
+import mlir.astnodes as mast
+import mlir.dialects.standard as std
+import mlir.dialects.affine as affine
+from typing import Optional, Tuple, Union, List, Any
+from contextlib import contextmanager
+from mlir.builder.match import Reads, Writes, Isa, All, And, Or, Not  # noqa: F401
+from mlir.builder.match import MatchExpressionBase
+from mlir.builder.ung import UniqueNameGenerator
+from dataclasses import dataclass
+
+
+__doc__ = """
+.. currentmodule:: mlir.builder.builder
+
+.. autoclass:: IRBuilder
+.. autoclass:: AffineBuilder
+"""
+
+
+class IRBuilder:
+    """
+    MLIR AST builder. Provides convenience methods for adding core dialect
+    operations to a :class:`~mlir.astnodes.Block`.
+
+    .. attribute:: block
+
+        The block that the builder is operating on.
+
+    .. attribute:: position
+
+        An instance of :class:`int`, indicating the position where the next
+        operation is to be added in the :attr:`block`.
+
+    .. note::
+
+        * The concepts here at not true to the implementation in
+          llvm-project/mlir. It should be seen more of a convenience to emit MLIR
+          modules.
+
+        * This class shared design elements from :class:`llvmlite.ir.IRBuilder`,
+          querying mechanism from :mod:`loopy`.
+
+    *Registering a custom dialect builder*
+
+    .. automethod:: register_dialect
+
+    *Position/block manipulation*
+
+    .. automethod:: position_at_entry
+    .. automethod:: position_at_exit
+    .. automethod:: goto_block
+    .. automethod:: goto_entry_block
+    .. automethod:: goto_before
+    .. automethod:: goto_after
+
+    *Types*
+
+    :attr F16: f16 type
+    :attr F32: f32 type
+    :attr F64: f64 type
+    :attr INT32: i32 type
+    :attr INT64: i64 type
+    :attr INDEX: index type
+
+    .. automethod:: MemRefType
+
+    *Standard dialect ops*
+
+    .. automethod:: dim
+    .. automethod:: addf
+    .. automethod:: mulf
+    .. automethod:: index_constant
+    .. automethod:: float_constant
+    """
+
+    def __init__(self):
+        self.block = None
+        self.position = None
+
+        self._dialects = {
+            "affine": AffineBuilder(self),
+            "std": self,  # std dialect ops can also be globally referenced
+        }
+
+    name_gen = UniqueNameGenerator(forced_prefix="_pymlir_")
+
+    F16 = mast.FloatType(type=mast.FloatTypeEnum.f16)
+    F32 = mast.FloatType(type=mast.FloatTypeEnum.f32)
+    F64 = mast.FloatType(type=mast.FloatTypeEnum.f64)
+    INT32 = mast.IntegerType(32)
+    INT64 = mast.IntegerType(64)
+    INDEX = mast.IndexType()
+
+    def __getattr__(self, item: str) -> Any:
+        if item in self._dialects:
+            return self._dialects[item]
+
+        return super().__getattr__(item)
+
+    def register_dialect(self, name: str,
+                         dialect_builder: "DialectBuilder",
+                         overwrite: bool = False) -> None:
+        if name in self._dialects and not overwrite:
+            raise ValueError(f"'{name}' already registered as a dialect.")
+
+        self._dialects[name] = dialect_builder
+
+    @staticmethod
+    def make_mlir_file(module: Optional[mast.Module] = None) -> mast.MLIRFile:
+        """
+        Returns an instance of :class:`mlir.astnodes.MLIRFile` for *module*.  If
+        *module* is *None*, defaults it with an empty :class:`mlir.astnodes.Module`.
+        """
+        if module is None:
+            module = mast.Module(None, None, mast.Region([]))
+        return mast.MLIRFile([], [module])
+
+    def module(self, name: Optional[str] = None) -> mast.Module:
+        """
+        Inserts a :class:`mlir.astnodes.Module` with name *name* into *block*.
+
+        Returns the inserted module.
+        """
+        if name is None:
+            name = None
+        else:
+            name = mast.SymbolRefId(name)
+
+        op = mast.Module(name, None, mast.Region([]))
+        self._insert_op_in_block([], op)
+        return op
+
+    def function(self, name: Optional[str] = None) -> mast.Function:
+        """
+        Inserts a :class:`mlir.astnodes.Function` with name *name* into *block*.
+
+        Returns the inserted function.
+        """
+        if name is None:
+            name = self.name_gen("fn")
+
+        op = mast.Function(mast.SymbolRefId(value=name), [], [], None,
+                           mast.Region([]))
+
+        self._insert_op_in_block([], op)
+        return op
+
+    @classmethod
+    def make_block(cls, region: mast.Region, name: Optional[str] = None
+                   ) -> mast.Block:
+        """
+        Appends a :class:`mlir.astnodes.Block` with name *name* to the *region*.
+
+        Returns the appended block.
+        """
+        if name is None:
+            label = None
+        else:
+            label = mast.BlockLabel(name, [], [])
+
+        block = mast.Block(label, [])
+        region.body.append(block)
+        return block
+
+    @classmethod
+    def add_function_args(cls, function: mast.Function, dtypes: List[mast.Type],
+                          names: Optional[List[str]] = None,
+                          positions: Optional[List[int]] = None):
+        """
+        Adds arguments to *function*.
+
+        :arg dtypes: Types of the arguments to be added to the function.
+        :arg names: Names of the arguments to be added to the function.
+        :arg positions: Positions where the arguments are to be inserted.
+        """
+        if names is None:
+            names = [cls.name_gen("fnarg") for _ in dtypes]
+
+        if function.args is None:
+            function.args = []
+
+        if positions is None:
+            positions = list(range(len(function.args),
+                                   len(function.args) + len(dtypes)))
+
+        args = []
+
+        for name, dtype, pos in zip(names, dtypes, positions):
+            arg = mast.SsaId(name)
+            function.args.insert(pos, mast.NamedArgument(arg, dtype))
+            args.append(arg)
+
+        return args
+
+    def MemRefType(self,
+                   dtype: mast.Type,
+                   shape: Optional[Tuple[Optional[int], ...]],
+                   offset: Optional[int] = None,
+                   strides: Optional[Tuple[Optional[int], ...]] = None
+                   ) -> mast.MemRefType:
+        """
+        Returns an instance of :class:`mlir.astnodes.UnrankedMemRefType` if shape is
+        *None*, else returns a :class:`mlir.astnodes.RankedMemRefType`.
+        """
+        if shape is None:
+            assert strides is None
+            return mast.UnrankedMemRefType(dtype)
+        else:
+            shape = tuple(mast.Dimension(dim) for dim in shape)
+            if strides is None and offset is None:
+                layout = None
+            else:
+                if offset is None:
+                    offset = 0
+                if strides is not None:
+                    if len(shape) != len(strides):
+                        raise ValueError("shapes and strides must be of tuples"
+                                         " of same dimensionality.")
+                layout = mast.StridedLayout(strides, offset)
+
+            return mast.RankedMemRefType(shape, dtype, layout)
+
+    def _insert_op_in_block(self,
+                            op_results: List[Optional[Union[mast.SsaId, str]]],
+                            op):
+        new_op_results = []
+        for op_result in op_results:
+            if op_result is None:
+                op_result = self.name_gen("ssa")
+
+            if isinstance(op_result, str):
+                result = mast.SsaId(op_result)
+
+            new_op_results.append(result)
+
+        if self.block is None:
+            raise ValueError("Not within any block to append")
+
+        self.block.body.insert(self.position,
+                               mast.Operation(result_list=new_op_results,
+                                             op=op))
+        self.position += 1
+
+        if len(new_op_results) == 1:
+            return new_op_results[0]
+        elif len(new_op_results) > 1:
+            return new_op_results
+        else:
+            return
+
+    # {{{ position/block manipulation
+
+    def position_at_entry(self, block: mast.Block):
+        """
+        Starts building at *block*'s entry.
+        """
+        self.block = block
+        self.position = 0
+
+    def position_at_exit(self, block: mast.Block):
+        """
+        Starts building at *block*'s exit.
+        """
+        self.block = block
+        self.position = len(block.body)
+
+    @contextmanager
+    def goto_block(self, block: mast.Block):
+        """
+        Context to start building at *block*'s exit.
+
+        Example usage::
+
+            with builder.goto_block(block):
+                # starts building at *block*'s exit.
+                z = builder.addf(x, y, F64)
+
+            # goes back to building at the builder's earlier position
+        """
+        parent_block = self.block
+        parent_position = self.position
+
+        self.position_at_exit(block)
+        yield
+
+        self.block = parent_block
+        self.position = parent_position
+
+    @contextmanager
+    def goto_entry_block(self, block: mast.Block):
+        """
+        Context to start building at *block*'s entry.
+
+        Example usage::
+
+            with builder.goto_block(block):
+                # starts building at *block*'s entry.
+                z = builder.addf(x, y, F64)
+
+            # goes back to building at the builder's earlier position
+        """
+        parent_block = self.block
+        parent_position = self.position
+
+        self.position_at_entry(block)
+        yield
+
+        self.block = parent_block
+        self.position = parent_position
+
+    def position_before(self, query: MatchExpressionBase,
+                        block: Optional[mast.Block] = None):
+        """
+        Positions the builder to the point just before *query* gets matched in
+        *block*.
+
+        :arg block: Block to query the operations in. Defaults to the builder's
+            block.
+
+        Example usage::
+
+            builder.position_before(Reads("%c0") & Isa(AddfOperation))
+            # starts building before operation of form "... = addf %c0, ..."
+        """
+        if block is not None:
+            self.block = block
+
+        try:
+            self.position = next((i
+                                  for i, op in enumerate(self.block.body)
+                                  if query(op)))
+        except StopIteration:
+            raise ValueError(f"Did not find an operation matching '{query}'.")
+
+    def position_after(self, query, block: Optional[mast.Block] = None):
+        """
+        Positions the builder to the point just after *query* gets matched in
+        *block*.
+
+        :arg block: Block to query the operations in. Defaults to the builder's
+            block.
+
+        Example usage::
+
+            builder.position_after(Writes("%c0") & Isa(ConstantOperation))
+            # starts building after operation of form "%c0 = constant ...: ..."
+        """
+        if block is not None:
+            self.block = block
+
+        try:
+            self.position = next((i
+                                  for i, op in zip(range(len(self.block.body)-1,
+                                                         -1, -1),
+                                                   reversed(self.block.body))
+                                  if query(op))) + 1
+        except StopIteration:
+            raise ValueError(f"Did not find an operation matching '{query}'.")
+
+    @contextmanager
+    def goto_before(self, query: MatchExpressionBase,
+                    block: Optional[mast.Block] = None):
+        """
+        Enters a context to build at the point just before *query* gets matched in
+        *block*.
+
+        :arg block: Block to query the operations in. Defaults to the builder's
+            block.
+
+        Example usage::
+
+            with builder.goto_before(Reads("%c0") & Isa(AddfOperation)):
+                # starts building before operation of form "... = addf %c0, ..."
+                z = builder.mulf(x, y, F64)
+            # goes back to building at the builder's earlier position
+        """
+        parent_block = self.block
+        parent_position = self.position
+
+        self.position_before(query, block)
+
+        entered_at = self.position
+        yield
+
+        exit_at = self.position
+        self.block = parent_block
+
+        # accounting for operations added within the context
+        if entered_at <= parent_position:
+            parent_position += (exit_at - entered_at)
+
+        self.position = parent_position + (exit_at - entered_at)
+
+    @contextmanager
+    def goto_after(self, query: MatchExpressionBase,
+                   block: Optional[mast.Block] = None):
+        """
+        Enters a context to build at the point just after *query* gets matched in
+        *block*.
+
+        :arg block: Block to query the operations in. Defaults to the builder's
+            block.
+
+        Example usage::
+
+            with builder.goto_after(Writes("%c0") & Isa(ConstantOperation)):
+                # starts building after operation of form "%c0 = constant ...: ..."
+                z = builder.dim(x, c0, builder.INDEX)
+
+            # goes back to building at the builder's earlier position
+        """
+        parent_block = self.block
+        parent_position = self.position
+
+        self.position_after(query, block)
+
+        entered_at = self.position
+        yield
+
+        exit_at = self.position
+        self.block = parent_block
+
+        # accounting for operations added within the context
+        if entered_at <= parent_position:
+            parent_position += (exit_at - entered_at)
+
+        self.position = parent_position
+
+    # }}}
+
+    # {{{ standard dialect
+
+    def addf(self, op_a: mast.SsaId, op_b: mast.SsaId, type: mast.Type,
+             name: Optional[str] = None):
+        op = std.AddfOperation(match=0, operand_a=op_a, operand_b=op_b, type=type)
+        return self._insert_op_in_block([name], op)
+
+    def mulf(self, op_a: mast.SsaId, op_b: mast.SsaId, type: mast.Type,
+             name: Optional[str] = None):
+        op = std.MulfOperation(match=0, operand_a=op_a, operand_b=op_b, type=type)
+        return self._insert_op_in_block([name], op)
+
+    def dim(self, memref_or_tensor: mast.SsaId, index: mast.SsaId,
+            memref_type: Union[mast.MemRefType, mast.TensorType],
+            name: Optional[str] = None):
+        op = std.DimOperation(match=0, operand=memref_or_tensor, index=index,
+                              type=memref_type)
+        return self._insert_op_in_block([name], op)
+
+    def index_constant(self, value: int, name: Optional[str] = None):
+        op = std.ConstantOperation(match=0, value=value, type=mast.IndexType())
+        return self._insert_op_in_block([name], op)
+
+    def float_constant(self, value: float, type: mast.FloatType,
+                       name: Optional[str] = None):
+        op = std.ConstantOperation(match=0, value=value, type=type)
+        return self._insert_op_in_block([name], op)
+
+    # }}}
+
+    def ret(self, values: Optional[List[mast.SsaId]] = None,
+            types: Optional[List[mast.Type]] = None):
+
+        op = std.ReturnOperation(match=0, values=values, types=types)
+        self._insert_op_in_block([], op)
+        self.block = None
+        self.position = 0
+
+
+@dataclass
+class DialectBuilder:
+    """
+    A dialect-specific IR Builder.
+    """
+    core_builder: IRBuilder
+
+
+class AffineBuilder(DialectBuilder):
+    """
+    Affine dialect ops builder.
+
+    .. automethod:: for_
+    .. automethod:: load
+    .. automethod:: store
+    """
+
+    def for_(self, lower_bound: Union[int, mast.SsaId],
+             upper_bound: Union[int, mast.SsaId],
+             step: Optional[int] = None, indexname: Optional[str] = None):
+        if indexname is None:
+            indexname = self.core_builder.name_gen("i")
+            index = mast.AffineSsa(indexname)
+
+        if step is None:
+            match = 0
+        else:
+            match = 1
+
+        op = affine.AffineForOp(match=match,
+                                index=index,
+                                begin=lower_bound, end=upper_bound, step=step,
+                                region=mast.Region(body=[]))
+
+        self.core_builder._insert_op_in_block([], op)
+        return op
+
+    def load(self, memref: mast.SsaId,
+             indices: Union[mast.AffineExpr, List[mast.AffineExpr]],
+             memref_type: mast.MemRefType, name: Optional[str] = None):
+        if isinstance(indices, mast.AffineExpr):
+            indices = [indices]
+
+        op = affine.AffineLoadOp(match=0, arg=memref,
+                                 index=mast.MultiDimAffineExpr(indices),
+                                 type=memref_type)
+        return self.core_builder._insert_op_in_block([name], op)
+
+    def store(self, address: mast.SsaId, memref: mast.SsaId,
+              indices: Union[mast.AffineExpr, List[mast.AffineExpr]],
+              memref_type: mast.MemRefType):
+        if isinstance(indices, mast.AffineExpr):
+            indices = [indices]
+
+        op = affine.AffineStoreOp(match=0, addr=address, ref=memref,
+                                  index=mast.MultiDimAffineExpr(indices),
+                                  type=memref_type)
+        self.core_builder._insert_op_in_block([], op)
+
+
+# vim: fdm=marker

--- a/mlir/builder/match.py
+++ b/mlir/builder/match.py
@@ -1,0 +1,125 @@
+"""Operation query interface."""
+
+import mlir.astnodes as ast
+from mlir.visitors import NodeVisitor
+from typing import List, Union
+from dataclasses import dataclass
+
+
+__doc__ = """
+.. currentmodule:: mlir.builder.match
+
+Querying expressions
+====================
+
+.. autoclass:: All
+.. autoclass:: And
+.. autoclass:: Or
+.. autoclass:: Not
+.. autoclass:: Reads
+.. autoclass:: Writes
+.. autoclass:: Isa
+"""
+
+
+class SsaIdCollector(NodeVisitor):
+    """
+    A visitor to collect all the visited :class:`SsaId`'s in a node.
+    """
+    def __init__(self):
+        self.visited_ssas = []
+
+    def visit_SsaId(self, ssa: ast.SsaId):
+        self.visited_ssas.append(ssa)
+
+
+class MatchExpressionBase:
+    def __call__(self, op: ast.Operation) -> bool:
+        raise NotImplementedError()
+
+    def __and__(self, other: "MatchExpressionBase") -> "And":
+        return And([self, other])
+
+    def __or__(self, other: "MatchExpressionBase") -> "Or":
+        return Or([self, other])
+
+
+class All(MatchExpressionBase):
+    """
+    Matches with all nodes.
+    """
+    def __call__(self, op: ast.Operation) -> bool:
+        return True
+
+
+@dataclass
+class And(MatchExpressionBase):
+    """
+    Matches if all its children match.
+    """
+    children: List[MatchExpressionBase]
+
+    def __call__(self, op: ast.Operation) -> bool:
+        return all(ch(op) for ch in self.children)
+
+
+@dataclass
+class Or(MatchExpressionBase):
+    """
+    Matches if any of its children match.
+    """
+    children: List[MatchExpressionBase]
+
+    def __call__(self, op: ast.Operation) -> bool:
+        return any(ch(op) for ch in self.children)
+
+
+@dataclass
+class Not(MatchExpressionBase):
+    """
+    Matches if the child does not match.
+    """
+    child: MatchExpressionBase
+
+    def __call__(self, op: ast.Operation) -> bool:
+        return not self.child(op)
+
+
+@dataclass
+class Reads(MatchExpressionBase):
+    """
+    Matches the variables read by the operation.
+    """
+    name: Union[str, ast.SsaId]
+
+    def __call__(self, op: ast.Operation) -> bool:
+        collector = SsaIdCollector()
+        collector.visit(op.op)
+        visited_ssas = collector.visited_ssas
+        return any((ssa == self.name) or (ssa.dump() == self.name)
+                   for ssa in visited_ssas)
+
+
+@dataclass
+class Writes(MatchExpressionBase):
+    """
+    Matches the variable names written by the operation.
+    """
+    name: Union[str, ast.SsaId]
+
+    def __call__(self, op: ast.Operation) -> bool:
+        return any((ssa == self.name) or (ssa.dump() == self.name)
+                   for ssa in op.result_list)
+
+
+@dataclass
+class Isa(MatchExpressionBase):
+    """
+    Matches the operation's type.
+    """
+    type: type
+
+    def __call__(self, op: ast.Operation) -> bool:
+        return isinstance(op.op, self.type)
+
+# vim: fdm=marker

--- a/mlir/builder/ung.py
+++ b/mlir/builder/ung.py
@@ -1,0 +1,81 @@
+"""A boiled down version of UniqueNameGenerator from github.com/inducer/pytools"""
+
+__copyright__ = "Copyright (C) 2009-2013 Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from typing import Dict, Optional, Set, Iterable, Tuple
+
+
+# {{{ unique name generation
+
+def generate_unique_names(prefix):
+    yield prefix
+
+    try_num = 0
+    while True:
+        yield "%s_%d" % (prefix, try_num)
+        try_num += 1
+
+
+def generate_numbered_unique_names(
+        prefix: str, num: Optional[int] = None) -> Iterable[Tuple[int, str]]:
+    if num is None:
+        yield (0, prefix)
+        num = 0
+
+    while True:
+        name = "%s_%d" % (prefix, num)
+        num += 1
+        yield (num, name)
+
+
+class UniqueNameGenerator:
+    """
+    .. automethod:: is_name_conflicting
+    .. automethod:: __call__
+    """
+    def __init__(self,
+            existing_names: Optional[Set[str]] = None,
+            forced_prefix: str = ""):
+        if existing_names is None:
+            existing_names = set()
+
+        self.existing_names = existing_names.copy()
+        self.forced_prefix = forced_prefix
+        self.prefix_to_counter: Dict[str, int] = {}
+
+    def is_name_conflicting(self, name: str) -> bool:
+        return name in self.existing_names
+
+    def __call__(self, based_on: str) -> str:
+        based_on = self.forced_prefix + based_on
+
+        counter = self.prefix_to_counter.get(based_on, None)
+
+        for counter, var_name in generate_numbered_unique_names(based_on, counter):  # noqa: B007,E501
+            if not self.is_name_conflicting(var_name):
+                break
+
+        self.prefix_to_counter[based_on] = counter
+
+        self.existing_names.add(var_name)
+        return var_name
+
+# }}}

--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -256,7 +256,7 @@ affine_expr : "(" affine_expr ")"                      -> affine_parens
             | "symbol" "(" ssa_id ")"                  -> affine_symbol_explicit
             | posneg_integer_literal                   -> affine_literal
             | ssa_id                                   -> affine_ssa
-            | bare_id                                  -> affine_symbol
+            | bare_id                                  -> affine_dim_or_symbol
 
 semi_affine_expr : "(" semi_affine_expr ")"                        -> semi_affine_parens
                  | semi_affine_expr "+" semi_affine_expr           -> semi_affine_add

--- a/mlir/parser_transformer.py
+++ b/mlir/parser_transformer.py
@@ -240,8 +240,8 @@ class TreeToMlir(Transformer):
     integer_set = lambda self, value: value[0]
     affine_literal = lambda self, value: value[0]
     semi_affine_literal = lambda self, value: value[0]
-    affine_ssa = lambda self, value: value[0]
-    affine_symbol = lambda self, value: value[0]
+    affine_ssa = lambda self, value: astnodes.AffineSsa(value[0].value, value[0].op_no)
+    affine_dim_or_symbol = astnodes.AffineDimOrSymbol.from_lark
     semi_affine_symbol = lambda self, value: value[0]
 
     ###############################################################

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,111 @@
+import sys
+from mlir import parse_string
+from mlir.builder import IRBuilder
+from mlir.builder import Reads, Writes, Isa
+from mlir.dialects.affine import AffineLoadOp
+from mlir.dialects.standard import AddfOperation
+
+
+def test_saxpy_builder():
+    builder = IRBuilder()
+    F64 = builder.F64
+    Mref1D = builder.MemRefType(shape=(None, ), dtype=F64)
+
+    mlirfile = builder.make_mlir_file()
+    module = mlirfile.default_module
+
+    with builder.goto_block(builder.make_block(module.region)):
+        saxpy_fn = builder.function("saxpy")
+
+    block = builder.make_block(saxpy_fn.region)
+    builder.position_at_entry(block)
+
+    a, x, y = builder.add_function_args(saxpy_fn, [F64, Mref1D, Mref1D])
+    c0 = builder.index_constant(0)
+    n = builder.dim(x, c0, builder.INDEX)
+
+    f = builder.affine.for_(0, n)
+    i = f.index
+
+    with builder.goto_block(builder.make_block(f.region)):
+        axi = builder.mulf(builder.affine.load(x, i, Mref1D), a, F64)
+        axpyi = builder.addf(builder.affine.load(y, i, Mref1D), axi, F64)
+        builder.affine.store(axpyi, y, i, Mref1D)
+
+    builder.ret()
+
+    print(mlirfile.dump())
+
+
+def test_query():
+    block = parse_string("""
+func @saxpy(%a : f64, %x : memref<?xf64>, %y : memref<?xf64>) {
+%c0 = constant 0 : index
+%n = dim %x, %c0 : memref<?xf64>
+
+affine.for %i = 0 to %n {
+  %xi = affine.load %x[%i+1] : memref<?xf64>
+  %axi =  mulf %a, %xi : f64
+  %yi = affine.load %y[%i] : memref<?xf64>
+  %axpyi = addf %yi, %axi : f64
+  affine.store %axpyi, %y[%i] : memref<?xf64>
+}
+return
+}""").default_module.region.body[0].body[0].op.region.body[0]
+    for_block = block.body[2].op.region.body[0]
+
+    c0 = block.body[0].result_list[0].value
+
+    def query(expr):
+        return next((op
+                   for op in block.body + for_block.body
+                   if expr(op)))
+
+    assert query(Writes("%c0")).dump() == "%c0 = constant 0 : index"
+    assert (query(Reads("%y") & Isa(AffineLoadOp)).dump()
+            == "%yi = affine.load %y [ %i ] : memref<?xf64>")
+
+    assert query(Reads(c0)).dump() == "%n = dim %x , %c0 : memref<?xf64>"
+
+
+def test_build_with_queries():
+    builder = IRBuilder()
+    F64 = builder.F64
+
+    mlirfile = builder.make_mlir_file()
+    module = mlirfile.default_module
+
+    with builder.goto_block(builder.make_block(module.region)):
+        fn = builder.function("unorderly_adds")
+
+    a0, a1, b0, b1, c0, c1 = builder.add_function_args(fn, [F64]*6)
+
+    fnbody = builder.make_block(fn.region)
+    builder.position_at_entry(fnbody)
+
+    def index(expr):
+        return next((i
+                   for i, op in enumerate(fnbody.body)
+                   if expr(op)))
+
+    builder.addf(a0, a1, F64)
+
+    with builder.goto_before(Reads(a0) & Reads(a1)):
+        builder.addf(b0, b1, F64)
+
+    with builder.goto_after(Reads(b0) & Isa(AddfOperation)):
+        builder.addf(c0, c1, F64)
+
+    builder.ret()
+
+    assert index(Reads(b0)) == 0
+    assert index(Reads(c0)) == 1
+    assert index(Reads(a0)) == 2
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])


### PR DESCRIPTION
- This branch will have a cleaner diff with the one in #8.
- Although all the operations haven't been exposed through the builder yet, I thought it would be better to get the fundamental pieces in first.
- An example of building a saxpy using this builder:
```python
builder = IRBuilder()
F64 = builder.F64
Mref1D = builder.MemRefType(shape=(None, ), dtype=F64)

mlirfile = builder.make_mlir_file()
module = mlirfile.module

with builder.goto_block(builder.make_block(module.region)):
    saxpy_fn = builder.function("saxpy")

block = builder.make_block(saxpy_fn.region)
builder.position_at_entry(block)

a, x, y = builder.add_function_args(saxpy_fn, [F64, Mref1D, Mref1D])
c0 = builder.index_constant(0)
n = builder.dim(x, c0, builder.INDEX)

f = builder.affine_for(0, n)
i = f.index

with builder.goto_block(builder.make_block(f.region)):
    axi = builder.mulf(builder.affine_load(x, i, Mref1D), a, F64)
    axpyi = builder.addf(builder.affine_load(y, i, Mref1D), axi, F64)
    builder.affine_store(axpyi, y, i, Mref1D)

builder.ret()
```