### PR TITLE
Simplify parsing ceildiv/floordiv/mod

### DIFF
--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -251,9 +251,9 @@ affine_expr : "(" affine_expr ")"                      -> affine_parens
             | affine_expr "-" affine_expr              -> affine_sub
             | posneg_integer_literal "*" affine_expr   -> affine_mul
             | affine_expr "*" posneg_integer_literal   -> affine_mul
-            | affine_expr "&ceildiv&" integer_literal  -> affine_ceildiv
-            | affine_expr "&floordiv&" integer_literal -> affine_floordiv
-            | affine_expr "&mod&" integer_literal      -> affine_mod
+            | affine_expr "ceildiv" integer_literal    -> affine_ceildiv
+            | affine_expr "floordiv" integer_literal   -> affine_floordiv
+            | affine_expr "mod" integer_literal        -> affine_mod
             | "-" affine_expr                          -> affine_neg
             | "symbol" "(" ssa_id ")"                  -> affine_symbol_explicit
             | posneg_integer_literal                   -> affine_literal
@@ -265,9 +265,9 @@ semi_affine_expr : "(" semi_affine_expr ")"                        -> semi_affin
                  | semi_affine_expr "-" semi_affine_expr           -> semi_affine_sub
                  | symbol_or_const "*" semi_affine_expr            -> semi_affine_mul
                  | semi_affine_expr "*" symbol_or_const            -> semi_affine_mul
-                 | semi_affine_expr "&ceildiv&" semi_affine_oprnd  -> semi_affine_ceildiv
-                 | semi_affine_expr "&floordiv&" semi_affine_oprnd -> semi_affine_floordiv
-                 | semi_affine_expr "&mod&" semi_affine_oprnd      -> semi_affine_mod
+                 | semi_affine_expr "ceildiv" semi_affine_oprnd    -> semi_affine_ceildiv
+                 | semi_affine_expr "floordiv" semi_affine_oprnd   -> semi_affine_floordiv
+                 | semi_affine_expr "mod" semi_affine_oprnd        -> semi_affine_mod
                  | "symbol" "(" symbol_or_const ")"                -> semi_affine_symbol_explicit
                  | symbol_or_const                                 -> semi_affine_symbol
 

--- a/mlir/parser.py
+++ b/mlir/parser.py
@@ -82,13 +82,6 @@ class Parser(object):
             :return: A module node representing the root of the AST.
         """
 
-        # Pre-transform code to avoid parsing issues with ceildiv/floordiv/mod,
-        # in which two symbols could be parsed as one legal symbol (due to
-        # ignoring whitespace): "d0floordivs0"
-        code = code.replace(' floordiv ', '&floordiv&')
-        code = code.replace(' ceildiv ', '&ceildiv&')
-        code = code.replace(' mod ', '&mod&')
-
         # Parse the code using Lark
         tree = self.parser.parse(code)
 


### PR DESCRIPTION
I haven't been able to reproduce the problem described in these comments:

```
        # Pre-transform code to avoid parsing issues with ceildiv/floordiv/mod,
        # in which two symbols could be parsed as one legal symbol (due to
        # ignoring whitespace): "d0floordivs0"
```

This PR removes this transformation step.

I did run into a similar problem where `arith.constant 0 : index` was being parsed as `arith.constant0`. The root issue was in `bare_id`. I solved it by inlining the regexes, and introducing `plain_id`:

```
// Identifier syntax
//bare_id : (letter| underscore) (letter|digit|underscore|id_chars)*
plain_id : /[a-zA-Z_][a-zA-Z0-9_$]*/
bare_id : /[a-zA-Z_][a-zA-Z0-9_$.]*/
suffix_id : digits | bare_id
```

... and then replacing each instance of `bare_id "." bare_id` with `plain_id "." plain_id`. I can submit that as a PR if you'd like.