### PR TITLE
astnodes: Add regions to GenericOperation.

### DIFF
--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -509,6 +509,7 @@ class GenericOperation(Op):
     name: str
     args: Optional[List[SsaId]]
     successors: Optional[List[BlockId]]
+    regions: Optional[List["Region"]]
     attributes: Optional[AttributeDict]
     type: List[Type]
 
@@ -522,6 +523,8 @@ class GenericOperation(Op):
         result += ')'
         if self.successors:
             result += '[' + dump_or_value(self.successors, indent) + ']'
+        if self.regions:
+            result += ' ( ' + ', '.join(r.dump(indent) for r in self.regions) + ')'
         if self.attributes:
             result += ' ' + dump_or_value(self.attributes, indent)
         if isinstance(self.type, list):

--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -167,7 +167,7 @@ location : string_literal ":" decimal_literal ":" decimal_literal
 trailing_location : ("loc" "(" location ")")
 
 // Undefined operations in all dialects
-generic_operation : string_literal "(" optional_ssa_use_list ")" optional_successor_list optional_attr_dict trailing_type
+generic_operation : string_literal "(" optional_ssa_use_list ")" optional_successor_list optional_region_list optional_attr_dict trailing_type
 custom_operation  : bare_id "." bare_id optional_ssa_use_list trailing_type
 
 // Final operation definition
@@ -188,6 +188,7 @@ successor_list   : "[" block_id? ("," block_id)* "]"
 
 block           : optional_block_label operation_list
 region : "{" block* "}"
+region_list : "(" region? ("," region)* ")"
 
 // ---------------------------------------------------------------------
 // Optional types
@@ -213,6 +214,7 @@ region : "{" block* "}"
 ?optional_block_label                   : block_label?                         -> optional
 ?optional_symbol_use_list               : symbol_use_list?                     -> optional
 ?optional_successor_list                : successor_list?                      -> optional
+?optional_region_list                   : region_list?                         -> optional
 // ----------------------------------------------------------------------
 // Modules and functions
 

--- a/mlir/parser_transformer.py
+++ b/mlir/parser_transformer.py
@@ -206,6 +206,7 @@ class TreeToMlir(Transformer):
     block_arg_list = list
     definition_and_function_list = tuple
     definition_and_module_list = tuple
+    region_list = list
 
     ###############################################################
     # Composite types that should be reduced to sub-types

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -249,6 +249,40 @@ def test_generic_dialect_llvm(parser: Optional[Parser] = None):
     print(module.pretty())
 
 
+def test_generic_dialect_generic_op(parser: Optional[Parser] = None):
+    code = '''
+"module"() ( {
+  "func"() ( {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    %0 = "generic_op_with_region"(%arg0, %arg1) ( {
+      %1 = "std.addi"(%arg1, %arg0) : (i32, i32) -> i32
+      "std.return"(%1) : (i32) -> ()
+    }) : (i32, i32) -> i32
+    %2 = "generic_op_with_regions"(%0, %arg0) ( {
+      %3 = "std.subi"(%0, %arg0) : (i32, i32) -> i32
+      "std.return"(%3) : (i32) -> ()
+    }, {
+      %4 = "std.addi"(%3, %arg0) : (i32, i32) -> i32
+      "std.return"(%4) : (i32) -> ()
+    }) : (i32, i32) -> i32
+    %5 = "generic_op_with_region_and_attr"(%2, %arg0) ( {
+      %6 = "std.subi"(%2, %arg0) : (i32, i32) -> i32
+      "std.return"(%6) : (i32) -> ()
+    }) {attr = "string attribute"} : (i32, i32) -> i32
+    %7 = "generic_op_with_region_and_successor"(%5, %arg0)[^bb1] ( {
+      %8 = "std.addi"(%5, %arg0) : (i32, i32) -> i32
+      "std.br"(%8)[^bb1] : (i32) -> ()
+    }) {attr = "string attribute"} : (i32, i32) -> i32
+  ^bb1(%ret: i32):
+    "std.return"(%ret) : (i32) -> ()
+  }) {sym_name = "mlir_entry", type = (i32, i32) -> i32} : () -> ()
+}) : () -> ()
+    '''
+    parser = parser or Parser()
+    module = parser.parse(code)
+    print(module.pretty())
+
+
 def test_integer_sign(parser: Optional[Parser] = None):
     code = '''
 func @integer_test(%a: si16, %b: ui32, %c: i7) {
@@ -275,4 +309,5 @@ if __name__ == '__main__':
     test_generic_dialect_std(p)
     test_generic_dialect_std_cond_br(p)
     test_generic_dialect_llvm(p)
+    test_generic_dialect_generic_op(p)
     test_integer_sign(p)


### PR DESCRIPTION
Hi :)

I added an optional `regions` attribute to the `GenericOperation` as described in the official language reference: https://mlir.llvm.org/docs/LangRef/#operations (see "region-list").

I would appreciate your feedback and thank you very much for your work!