### PR TITLE
Refactor 'func' dialect ops out of the standard dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ast1 = mlir.parse_path('/path/to/file.mlir')
 ast2 = mlir.parse_file(open('/path/to/file.mlir', 'r'))
 ast3 = mlir.parse_string('''
 module {
-  func @toy_func(%tensor: tensor<2x3xf64>) -> tensor<3x2xf64> {
+  func.func @toy_func(%tensor: tensor<2x3xf64>) -> tensor<3x2xf64> {
     %t_tensor = "toy.transpose"(%tensor) { inplace = true } : (tensor<2x3xf64>) -> tensor<3x2xf64>
     return %t_tensor : tensor<3x2xf64>
   }
@@ -150,7 +150,7 @@ print(mlirfile.dump())
 prints:
 ```mlir
 module {
-  func @hello_world(%a: f64, %b: f64) {
+  func.func @hello_world(%a: f64, %b: f64) {
     %_pymlir_ssa = addf %a , %b : f64
     return %_pymlir_ssa : f64
   }

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -643,9 +643,9 @@ class Function(Node):
     def dump(self, indent=0) -> str:
         result = 'func'
         result += ' %s' % self.name.dump(indent)
-        if self.args:
-            result += '(%s)' % ', '.join(
-                dump_or_value(arg, indent) for arg in self.args)
+        arg_list = self.args if self.args else []
+        result += '(%s)' % ', '.join(
+            dump_or_value(arg, indent) for arg in arg_list)
         if self.result_types:
             if not isinstance(self.result_types, list):
                 result += ' -> ' + dump_or_value(self.result_types, indent)

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -641,7 +641,7 @@ class Function(Node):
     location: Optional[Location] = None
 
     def dump(self, indent=0) -> str:
-        result = 'func'
+        result = 'func.func'
         result += ' %s' % self.name.dump(indent)
         arg_list = self.args if self.args else []
         result += '(%s)' % ', '.join(

--- a/mlir/builder/builder.py
+++ b/mlir/builder/builder.py
@@ -3,6 +3,7 @@
 import mlir.astnodes as mast
 import mlir.dialects.standard as std
 import mlir.dialects.affine as affine
+import mlir.dialects.func as func 
 from typing import Optional, Tuple, Union, List, Any
 from contextlib import contextmanager
 from mlir.builder.match import Reads, Writes, Isa, All, And, Or, Not  # noqa: F401
@@ -81,6 +82,7 @@ class IRBuilder:
 
         self._dialects = {
             "affine": AffineBuilder(self),
+            "func": FuncBuilder(self),
             "std": self,  # std dialect ops can also be globally referenced
         }
 
@@ -460,14 +462,6 @@ class IRBuilder:
 
     # }}}
 
-    def ret(self, values: Optional[List[mast.SsaId]] = None,
-            types: Optional[List[mast.Type]] = None):
-
-        op = std.ReturnOperation(match=0, values=values, types=types)
-        self._insert_op_in_block([], op)
-        self.block = None
-        self.position = 0
-
 
 @dataclass
 class DialectBuilder:
@@ -527,6 +521,20 @@ class AffineBuilder(DialectBuilder):
                                   index=mast.MultiDimAffineExpr(indices),
                                   type=memref_type)
         self.core_builder._insert_op_in_block([], op)
+
+class FuncBuilder(DialectBuilder):
+    """
+    Func dialect ops builder.
+
+    .. automethod:: ret 
+    """
+    def ret(self, values: Optional[List[mast.SsaId]] = None,
+            types: Optional[List[mast.Type]] = None):
+
+        op = func.ReturnOperation(match=0, values=values, types=types)
+        self.core_builder._insert_op_in_block([], op)
+        self.block = None
+        self.position = 0
 
 
 # vim: fdm=marker

--- a/mlir/dialects/__init__.py
+++ b/mlir/dialects/__init__.py
@@ -2,6 +2,7 @@ from .affine import affine as affine_dialect
 from .standard import standard as std_dialect
 from .scf import scf as scf_dialect
 from .linalg import linalg
+from .func import func as func_dialect
 
 
-STANDARD_DIALECTS = [affine_dialect, std_dialect, scf_dialect, linalg]
+STANDARD_DIALECTS = [affine_dialect, std_dialect, scf_dialect, linalg, func_dialect]

--- a/mlir/dialects/func.py
+++ b/mlir/dialects/func.py
@@ -1,0 +1,60 @@
+
+import inspect
+import sys
+from typing import List, Tuple, Optional, Union
+from dataclasses import dataclass
+
+import mlir.astnodes as mast
+from mlir.dialect import Dialect, DialectOp, is_op
+
+Literal = Union[mast.StringLiteral, float, int, bool]
+SsaUse = Union[mast.SsaId, Literal]
+
+@dataclass
+class CallIndirectOperation(DialectOp):
+    func: mast.SymbolRefId
+    type: mast.FunctionType
+    args: Optional[List[SsaUse]] = None
+    argtypes: Optional[List[mast.Type]] = None
+    _syntax_ = ['func.call_indirect {func.symbol_ref_id} () : {type.function_type}',
+                'func.call_indirect {func.symbol_ref_id} ( {args.ssa_use_list} ) : {type.function_type}']
+
+
+@dataclass
+class CallOperation(DialectOp):
+    func: mast.SymbolRefId
+    type: mast.FunctionType
+    args: Optional[List[SsaUse]] = None
+    argtypes: Optional[List[mast.Type]] = None
+    _syntax_ = ['func.call {func.symbol_ref_id} () : {type.function_type}',
+                'func.call {func.symbol_ref_id} ( {args.ssa_use_list} ) : {argtypes.function_type}']
+
+@dataclass
+class ConstantOperation(DialectOp):
+    value: mast.SymbolRefId
+    type: mast.Type
+    _syntax_ = ['func.constant {value.symbol_ref_id} : {type.type}']
+
+# Note: The 'func.func' operation is defined as 'function' in mlir.lark.
+
+@dataclass
+class ReturnOperation(DialectOp):
+    values: Optional[List[SsaUse]] = None
+    types: Optional[List[mast.Type]] = None
+    _syntax_ = ['return',
+                'return {values.ssa_use_list} : {types.type_list_no_parens}']
+
+    def dump(self, indent: int = 0) -> str:
+        output = 'return'
+        if self.values:
+            output += ' ' + ', '.join([v.dump(indent) for v in self.values])
+        if self.types:
+            output += ' : ' + ', '.join([t.dump(indent) for t in self.types])
+
+        return output
+
+    
+
+# Inspect current module to get all classes defined above
+func = Dialect('func', ops=[m[1] for m in inspect.getmembers(
+    sys.modules[__name__], lambda obj: is_op(obj, __name__))])

--- a/mlir/dialects/standard.py
+++ b/mlir/dialects/standard.py
@@ -30,43 +30,7 @@ class CondBrOperation(DialectOp):
     _syntax_ = ['cond_br {cond.ssa_use} , {block_true.block_id} , {block_false.block_id}']
 
 
-@dataclass
-class ReturnOperation(DialectOp):
-    values: Optional[List[SsaUse]] = None
-    types: Optional[List[mast.Type]] = None
-    _syntax_ = ['return',
-                'return {values.ssa_use_list} : {types.type_list_no_parens}']
-    def dump(self, indent: int = 0) -> str:
-        output = 'return'
-        if self.values:
-            output += ' ' + ', '.join([v.dump(indent) for v in self.values])
-        if self.types:
-            output += ' : ' + ', '.join([t.dump(indent) for t in self.types])
-
-        return output
-
-    
 # Core Operations
-@dataclass
-class CallOperation(DialectOp):
-    func: mast.SymbolRefId
-    type: mast.FunctionType
-    args: Optional[List[SsaUse]] = None
-    argtypes: Optional[List[mast.Type]] = None
-    _syntax_ = ['call {func.symbol_ref_id} () : {type.function_type}',
-                'call {func.symbol_ref_id} ( {args.ssa_use_list} ) : {argtypes.function_type}']
-
-
-@dataclass
-class CallIndirectOperation(DialectOp):
-    func: mast.SymbolRefId
-    type: mast.FunctionType
-    args: Optional[List[SsaUse]] = None
-    argtypes: Optional[List[mast.Type]] = None
-    _syntax_ = ['call_indirect {func.symbol_ref_id} () : {type.function_type}',
-                'call_indirect {func.symbol_ref_id} ( {args.ssa_use_list} ) : {type.function_type}']
-
-
 @dataclass
 class DimOperation(DialectOp):
     operand: mast.SsaId

--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -233,7 +233,7 @@ function_result_list_parens : ("(" ")") | ("(" function_result_list_no_parens ")
 
 // Definition
 module : "module" optional_symbol_ref_id optional_func_mod_attrs region optional_trailing_loc
-function : "func" symbol_ref_id "(" optional_arg_list ")" optional_fn_result_list optional_func_mod_attrs optional_fn_body optional_trailing_loc
+function : "func.func" symbol_ref_id "(" optional_arg_list ")" optional_fn_result_list optional_func_mod_attrs optional_fn_body optional_trailing_loc
 generic_module : string_literal "(" optional_arg_list ")" "(" region ")" optional_attr_dict trailing_type optional_trailing_loc
 
 // ----------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lark-parser==0.7.8
 parse==1.14.0
+pytest

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,7 +3,6 @@ from mlir import parse_string
 from mlir.builder import IRBuilder
 from mlir.builder import Reads, Writes, Isa
 from mlir.dialects.affine import AffineLoadOp
-from mlir.dialects.func import func
 from mlir.dialects.standard import AddfOperation
 
 
@@ -52,7 +51,7 @@ affine.for %i = 0 to %n {
   affine.store %axpyi, %y[%i] : memref<?xf64>
 }
 return
-}""", dialects=[func]).default_module.region.body[0].body[0].op.region.body[0]
+}""").default_module.region.body[0].body[0].op.region.body[0]
     for_block = block.body[2].op.region.body[0]
 
     c0 = block.body[0].result_list[0].value

--- a/tests/test_custom_dialect.py
+++ b/tests/test_custom_dialect.py
@@ -4,6 +4,7 @@ from typing import List, Union, Optional
 from mlir import parse_string
 from mlir.astnodes import Node, dump_or_value, SsaId, StringLiteral, TensorType, MemRefType, Dimension
 from mlir.dialect import Dialect, DialectOp, DialectType
+from mlir.dialects.func import func
 from dataclasses import dataclass
 
 
@@ -77,12 +78,12 @@ toy_impl_list   : toy_impl_type ("+" toy_impl_type)*
 
 def test_custom_dialect():
     code = '''module {
-  func @toy_test(%ragged: !toy.ragged<coo+csr, 32x14xf64>) -> tensor<32x14xf64> {
+  func.func @toy_test(%ragged: !toy.ragged<coo+csr, 32x14xf64>) -> tensor<32x14xf64> {
     %t_tensor = toy.densify %ragged : tensor<32x14xf64>
     return %t_tensor : tensor<32x14xf64>
   }
 }'''
-    m = parse_string(code, dialects=[my_dialect])
+    m = parse_string(code, dialects=[func, my_dialect])
     dump = m.pretty()
     print(dump)
 

--- a/tests/test_custom_dialect.py
+++ b/tests/test_custom_dialect.py
@@ -83,7 +83,7 @@ def test_custom_dialect():
     return %t_tensor : tensor<32x14xf64>
   }
 }'''
-    m = parse_string(code, dialects=[func, my_dialect])
+    m = parse_string(code, dialects=[my_dialect])
     dump = m.pretty()
     print(dump)
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -7,7 +7,7 @@ from mlir.dialects.func import func
 
 
 def assert_roundtrip_equivalence(source):
-    assert source == mlir.parse_string(source, dialects=[func]).dump()
+    assert source == mlir.parse_string(source).dump()
 
 
 def test_batch_matmul():

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,17 +1,18 @@
 import sys
 import mlir
+from mlir.dialects.func import func 
 
 # All source strings have been taken from MLIR's codebase.
 # See llvm-project/mlir/test/Dialect/Linalg
 
 
 def assert_roundtrip_equivalence(source):
-    assert source == mlir.parse_string(source).dump()
+    assert source == mlir.parse_string(source, dialects=[func]).dump()
 
 
 def test_batch_matmul():
     assert_roundtrip_equivalence("""module {
-  func @named_ops(%a3: memref<?x?x?xf32>, %b3: memref<?x?x?xf32>, %c3: memref<?x?x?xf32>, %ta3: tensor<?x?x?xf32>, %tb3: tensor<?x?x?xf32>, %tc3: tensor<?x?x?xf32>) -> (tensor<?x?x?xf32>, tensor<?x?x?xf32>) {
+  func.func @named_ops(%a3: memref<?x?x?xf32>, %b3: memref<?x?x?xf32>, %c3: memref<?x?x?xf32>, %ta3: tensor<?x?x?xf32>, %tb3: tensor<?x?x?xf32>, %tc3: tensor<?x?x?xf32>) -> (tensor<?x?x?xf32>, tensor<?x?x?xf32>) {
     linalg.batch_matmul ins( %a3 , %b3 : memref<?x?x?xf32> , memref<?x?x?xf32> ) outs( %c3 : memref<?x?x?xf32> )
     linalg.batch_matmul ins( %ta3 , %tb3 : tensor<?x?x?xf32> , tensor<?x?x?xf32> ) outs( %c3 : memref<?x?x?xf32> )
     %res1 = linalg.batch_matmul ins( %ta3 , %tb3 : tensor<?x?x?xf32> , tensor<?x?x?xf32> ) init( %tc3 : tensor<?x?x?xf32> ) -> tensor<?x?x?xf32>
@@ -23,15 +24,15 @@ def test_batch_matmul():
 
 def test_conv():
     assert_roundtrip_equivalence("""module {
-  func @conv1d_no_symbols(%in: memref<?xf32>, %filter: memref<?xf32>, %out: memref<?xf32>) {
+  func.func @conv1d_no_symbols(%in: memref<?xf32>, %filter: memref<?xf32>, %out: memref<?xf32>) {
     linalg.conv_1d ins( %in , %filter : memref<?xf32> , memref<?xf32> ) outs( %out : memref<?xf32> )
     return
   }
-  func @conv2d_no_symbols(%in: memref<?x?xf32>, %filter: memref<?x?xf32>, %out: memref<?x?xf32>) {
+  func.func @conv2d_no_symbols(%in: memref<?x?xf32>, %filter: memref<?x?xf32>, %out: memref<?x?xf32>) {
     linalg.conv_2d ins( %in , %filter : memref<?x?xf32> , memref<?x?xf32> ) outs( %out : memref<?x?xf32> )
     return
   }
-  func @conv3d_no_symbols(%in: memref<?x?x?xf32>, %filter: memref<?x?x?xf32>, %out: memref<?x?x?xf32>) {
+  func.func @conv3d_no_symbols(%in: memref<?x?x?xf32>, %filter: memref<?x?x?xf32>, %out: memref<?x?x?xf32>) {
     linalg.conv_3d ins( %in , %filter : memref<?x?x?xf32> , memref<?x?x?xf32> ) outs( %out : memref<?x?x?xf32> )
     return
   }
@@ -40,11 +41,11 @@ def test_conv():
 
 def test_copy():
     assert_roundtrip_equivalence("""module {
-  func @copy_view(%arg0: memref<?xf32, offset: ?, strides: [1]>, %arg1: memref<?xf32, offset: ?, strides: [1]>) {
+  func.func @copy_view(%arg0: memref<?xf32, offset: ?, strides: [1]>, %arg1: memref<?xf32, offset: ?, strides: [1]>) {
     linalg.copy( %arg0 , %arg1 )  : memref<?xf32, offset: ?, strides: [1]> , memref<?xf32, offset: ?, strides: [1]>
     return
   }
-  func @copy_view3(%arg0: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, %arg1: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>) {
+  func.func @copy_view3(%arg0: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, %arg1: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>) {
     linalg.copy( %arg0 , %arg1 ) {inputPermutation = affine_map<(i, j, k) -> (i, k, j)>, outputPermutation = affine_map<(i, j, k) -> (k, j, i)>} : memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]> , memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>
     return
   }
@@ -53,7 +54,7 @@ def test_copy():
 
 def test_dot():
     assert_roundtrip_equivalence("""module {
-  func @dot(%arg0: memref<?xi8>, %M: index) {
+  func.func @dot(%arg0: memref<?xi8>, %M: index) {
     %c0 = constant 0 : index
     %c1 = constant 1 : index
     %1 = view %arg0 [ %c0 ] [ %M ] : memref<?xi8> to memref<?xf32>
@@ -67,7 +68,7 @@ def test_dot():
 
 def test_fill():
     assert_roundtrip_equivalence("""module {
-  func @fill_view(%arg0: memref<?xf32, offset: ?, strides: [1]>, %arg1: f32) {
+  func.func @fill_view(%arg0: memref<?xf32, offset: ?, strides: [1]>, %arg1: f32) {
     linalg.fill( %arg0 , %arg1 )  : memref<?xf32, offset: ?, strides: [1]> , f32
     return
   }
@@ -76,7 +77,7 @@ def test_fill():
 
 def test_generic():
     assert_roundtrip_equivalence("""module {
-  func @example(%A: memref<?x?xf64>, %B: memref<?x?xf64>, %C: memref<?x?xf64>) {
+  func.func @example(%A: memref<?x?xf64>, %B: memref<?x?xf64>, %C: memref<?x?xf64>) {
     linalg.generic {indexing_maps = [affine_map<(i, j) -> (i, j)>, affine_map<(i, j) -> (i, j)>, affine_map<(i, j) -> (i, j)>], iterator_types = ["parallel", "parallel"]}  ins( %A, %B : memref<?x?xf64>, memref<?x?xf64> ) outs( %C : memref<?x?xf64> ) {
       ^bb0 (%a: f64, %b: f64, %c: f64):
         %c0 = constant 3.14 : f64
@@ -90,7 +91,7 @@ def test_generic():
 
 def test_indexed_generic():
     assert_roundtrip_equivalence("""module {
-  func @indexed_generic_region(%arg0: memref<?x?xf32, offset: ?, strides: [?, 1]>, %arg1: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, %arg2: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>) {
+  func.func @indexed_generic_region(%arg0: memref<?x?xf32, offset: ?, strides: [?, 1]>, %arg1: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, %arg2: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>) {
     linalg.indexed_generic {args_in = 1, args_out = 2, iterator_types = ["parallel", "parallel", "parallel"], indexing_maps = [affine_map<(i, j, k) -> (i, j)>, affine_map<(i, j, k) -> (i, j, k)>, affine_map<(i, j, k) -> (i, k, j)>], library_call = "some_external_function_name_2", doc = "B(i,j,k), C(i,k,j) = foo(A(i, j) * B(i,j,k), i * j * k + C(i,k,j))"}  ins( %arg0 : memref<?x?xf32, offset: ?, strides: [?, 1]> ) outs( %arg1, %arg2 : memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]> ) {
       ^bb0 (%i: index, %j: index, %k: index, %a: f32, %b: f32, %c: f32):
         %result_1 = mulf %a , %b : f32
@@ -108,7 +109,7 @@ def test_indexed_generic():
 
 def test_view():
     assert_roundtrip_equivalence("""module {
-  func @views(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+  func.func @views(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
     %c0 = constant 0 : index
     %0 = muli %arg0 , %arg0 : index
     %1 = alloc (%0) : memref<?xi8>
@@ -127,7 +128,7 @@ def test_view():
 
 def test_matmul():
     assert_roundtrip_equivalence("""module {
-  func @matmul(%arg0: memref<?xi8>, %M: index, %N: index, %K: index) {
+  func.func @matmul(%arg0: memref<?xi8>, %M: index, %N: index, %K: index) {
     %c0 = constant 0 : index
     %c1 = constant 1 : index
     %A = view %arg0 [ %c0 ] [ %M, %K ] : memref<?xi8> to memref<?x?xf32>
@@ -141,7 +142,7 @@ def test_matmul():
 
 def test_matvec():
     assert_roundtrip_equivalence("""module {
-  func @matvec(%arg0: memref<?xi8>, %M: index, %N: index) {
+  func.func @matvec(%arg0: memref<?xi8>, %M: index, %N: index) {
     %c0 = constant 0 : index
     %c1 = constant 1 : index
     %2 = view %arg0 [ %c0 ] [ %M, %N ] : memref<?xi8> to memref<?x?xf32>

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -16,7 +16,7 @@ def test_toy_roundtrip():
   }
 }'''
 
-    module = parse_string(code, dialects=[func])
+    module = parse_string(code)
     dump = module.dump()
     assert dump == code
 
@@ -31,7 +31,7 @@ def test_function_no_args():
   }
 }'''
 
-    module = parse_string(code, dialects=[func])
+    module = parse_string(code)
     dump = module.dump()
     assert dump == code
 
@@ -60,7 +60,7 @@ def test_affine_expr_roundtrip():
 #set3 = (d0, d1, d2) : (d0 - d2 * 4 == 0, d0 + d1 * 8 - 9 >= 0, -d0 - d1 * 8 + 11 >= 0)
 #set4 = (d0, d1, d2, d3, d4, d5) : (d0 * 1089234 + d1 * 203472 + 82342 >= 0, d0 * -55 + d1 * 24 + d2 * 238 - d3 * 234 - 9743 >= 0, d0 * -5445 - d1 * 284 + d2 * 23 + d3 * 34 - 5943 >= 0, d0 * -5445 + d1 * 284 + d2 * 238 - d3 * 34 >= 0, d0 * 445 + d1 * 284 + d2 * 238 + d3 * 39 >= 0, d0 * -545 + d1 * 214 + d2 * 218 - d3 * 94 >= 0, d0 * 44 - d1 * 184 - d2 * 231 + d3 * 14 >= 0, d0 * -45 + d1 * 284 + d2 * 138 - d3 * 39 >= 0, d0 * 154 - d1 * 84 + d2 * 238 - d3 * 34 >= 0, d0 * 54 - d1 * 284 - d2 * 223 + d3 * 384 >= 0, d0 * -55 + d1 * 284 + d2 * 23 + d3 * 34 >= 0, d0 * 54 - d1 * 84 + d2 * 28 - d3 * 34 >= 0, d0 * 54 - d1 * 24 - d2 * 23 + d3 * 34 >= 0, d0 * -55 + d1 * 24 + d2 * 23 + d3 * 4 >= 0, d0 * 15 - d1 * 84 + d2 * 238 - d3 * 3 >= 0, d0 * 5 - d1 * 24 - d2 * 223 + d3 * 84 >= 0, d0 * -5 + d1 * 284 + d2 * 23 - d3 * 4 >= 0, d0 * 14 + d2 * 4 + 7234 >= 0, d0 * -174 - d2 * 534 + 9834 >= 0, d0 * 194 - d2 * 954 + 9234 >= 0, d0 * 47 - d2 * 534 + 9734 >= 0, d0 * -194 - d2 * 934 + 984 >= 0, d0 * -947 - d2 * 953 + 234 >= 0, d0 * 184 - d2 * 884 + 884 >= 0, d0 * -174 + d2 * 834 + 234 >= 0, d0 * 844 + d2 * 634 + 9874 >= 0, d2 * -797 - d3 * 79 + 257 >= 0, d0 * 2039 + d2 * 793 - d3 * 99 - d4 * 24 + d5 * 234 >= 0, d2 * 78 - d5 * 788 + 257 >= 0, d3 - (d5 + d0 * 97) floordiv 423 >= 0, ((d0 + (d3 mod 5) floordiv 2342) * 234) mod 2309 + (d0 + d3 * 2038) floordiv 208 >= 0, ((((d0 + d3 * 2300) * 239) floordiv 2342) mod 2309) mod 239423 == 0, d0 + d3 mod 2642 + (((((d3 + d0 * 2) mod 1247) mod 2038) mod 2390) mod 2039) floordiv 55 >= 0)
 '''
-    module = parse_string(code, dialects=[func])
+    module = parse_string(code)
     assert module.dump() == code
 
 
@@ -80,7 +80,7 @@ def test_loop_dialect_roundtrip():
     return
   }
 }"""
-    assert parse_string(src, dialects=[func]).dump() == src
+    assert parse_string(src).dump() == src
 
 
 if __name__ == '__main__':

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -19,6 +19,20 @@ def test_toy_roundtrip():
     dump = module.dump()
     assert dump == code
 
+def test_function_no_args():
+    """
+    Test round-tripping a function with no arguments.
+    """
+    code = '''module {
+  func @toy_func() -> index {
+    %c0 = constant 0 : index
+    return %0 : index
+  }
+}'''
+
+    module = parse_string(code)
+    dump = module.dump()
+    assert dump == code
 
 def test_affine_expr_roundtrip():
     """

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -25,13 +25,13 @@ def test_function_no_args():
     Test round-tripping a function with no arguments.
     """
     code = '''module {
-  func @toy_func() -> index {
-    %c0 = constant 0 : index
+  func.func @toy_func() -> index {
+    %0 = constant 0 : index
     return %0 : index
   }
 }'''
 
-    module = parse_string(code)
+    module = parse_string(code, dialects=[func])
     dump = module.dump()
     assert dump == code
 

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -1,6 +1,7 @@
 """ Tests pyMLIR in a parse->dump->parse round-trip. """
 
 from mlir import parse_string
+from mlir.dialects.func import func 
 
 
 def test_toy_roundtrip():
@@ -9,13 +10,13 @@ def test_toy_roundtrip():
     and dump the same way.
     """
     code = '''module {
-  func @toy_func(%arg0: tensor<2x3xf64>) -> tensor<3x2xf64> {
+  func.func @toy_func(%arg0: tensor<2x3xf64>) -> tensor<3x2xf64> {
     %0 = "toy.transpose"(%arg0) {inplace = true} : (tensor<2x3xf64>) -> tensor<3x2xf64>
     return %0 : tensor<3x2xf64>
   }
 }'''
 
-    module = parse_string(code)
+    module = parse_string(code, dialects=[func])
     dump = module.dump()
     assert dump == code
 
@@ -59,13 +60,13 @@ def test_affine_expr_roundtrip():
 #set3 = (d0, d1, d2) : (d0 - d2 * 4 == 0, d0 + d1 * 8 - 9 >= 0, -d0 - d1 * 8 + 11 >= 0)
 #set4 = (d0, d1, d2, d3, d4, d5) : (d0 * 1089234 + d1 * 203472 + 82342 >= 0, d0 * -55 + d1 * 24 + d2 * 238 - d3 * 234 - 9743 >= 0, d0 * -5445 - d1 * 284 + d2 * 23 + d3 * 34 - 5943 >= 0, d0 * -5445 + d1 * 284 + d2 * 238 - d3 * 34 >= 0, d0 * 445 + d1 * 284 + d2 * 238 + d3 * 39 >= 0, d0 * -545 + d1 * 214 + d2 * 218 - d3 * 94 >= 0, d0 * 44 - d1 * 184 - d2 * 231 + d3 * 14 >= 0, d0 * -45 + d1 * 284 + d2 * 138 - d3 * 39 >= 0, d0 * 154 - d1 * 84 + d2 * 238 - d3 * 34 >= 0, d0 * 54 - d1 * 284 - d2 * 223 + d3 * 384 >= 0, d0 * -55 + d1 * 284 + d2 * 23 + d3 * 34 >= 0, d0 * 54 - d1 * 84 + d2 * 28 - d3 * 34 >= 0, d0 * 54 - d1 * 24 - d2 * 23 + d3 * 34 >= 0, d0 * -55 + d1 * 24 + d2 * 23 + d3 * 4 >= 0, d0 * 15 - d1 * 84 + d2 * 238 - d3 * 3 >= 0, d0 * 5 - d1 * 24 - d2 * 223 + d3 * 84 >= 0, d0 * -5 + d1 * 284 + d2 * 23 - d3 * 4 >= 0, d0 * 14 + d2 * 4 + 7234 >= 0, d0 * -174 - d2 * 534 + 9834 >= 0, d0 * 194 - d2 * 954 + 9234 >= 0, d0 * 47 - d2 * 534 + 9734 >= 0, d0 * -194 - d2 * 934 + 984 >= 0, d0 * -947 - d2 * 953 + 234 >= 0, d0 * 184 - d2 * 884 + 884 >= 0, d0 * -174 + d2 * 834 + 234 >= 0, d0 * 844 + d2 * 634 + 9874 >= 0, d2 * -797 - d3 * 79 + 257 >= 0, d0 * 2039 + d2 * 793 - d3 * 99 - d4 * 24 + d5 * 234 >= 0, d2 * 78 - d5 * 788 + 257 >= 0, d3 - (d5 + d0 * 97) floordiv 423 >= 0, ((d0 + (d3 mod 5) floordiv 2342) * 234) mod 2309 + (d0 + d3 * 2038) floordiv 208 >= 0, ((((d0 + d3 * 2300) * 239) floordiv 2342) mod 2309) mod 239423 == 0, d0 + d3 mod 2642 + (((((d3 + d0 * 2) mod 1247) mod 2038) mod 2390) mod 2039) floordiv 55 >= 0)
 '''
-    module = parse_string(code)
+    module = parse_string(code, dialects=[func])
     assert module.dump() == code
 
 
 def test_loop_dialect_roundtrip():
     src = """module {
-  func @for(%outer: index, %A: memref<?xf32>, %B: memref<?xf32>, %C: memref<?xf32>, %result: memref<?xf32>) {
+  func.func @for(%outer: index, %A: memref<?xf32>, %B: memref<?xf32>, %C: memref<?xf32>, %result: memref<?xf32>) {
     %c0 = constant 0 : index
     %c1 = constant 1 : index
     %d0 = dim %A , %c0 : memref<?xf32>
@@ -79,7 +80,7 @@ def test_loop_dialect_roundtrip():
     return
   }
 }"""
-    assert parse_string(src).dump() == src
+    assert parse_string(src, dialects=[func]).dump() == src
 
 
 if __name__ == '__main__':

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 @pytest.fixture
 def parser(parser: Optional[Parser] = None) -> Parser:
-    return parser if parser is not None else Parser(dialects=[func])
+    return parser if parser is not None else Parser()
 
 def test_attributes(parser):
     code = '''
@@ -300,7 +300,7 @@ func.func @integer_test(%a: si16, %b: ui32, %c: i7) {
 
 
 if __name__ == '__main__':
-    p = Parser(dialects=[func])
+    p = Parser()
     print("MLIR parser created")
     test_attributes(p)
     test_memrefs(p)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -9,7 +9,7 @@ from typing import Optional
 def parser(parser: Optional[Parser] = None) -> Parser:
     return parser if parser is not None else Parser()
 
-def test_attributes(parser):
+def test_attributes(parser: Optional[Parser] = None):
     code = '''
 module {
   func.func @myfunc(%tensor: tensor<256x?xf64>) -> tensor<*xf64> {
@@ -27,7 +27,7 @@ module {
     print(module.pretty())
 
 
-def test_memrefs(parser):
+def test_memrefs(parser: Optional[Parser] = None):
     code = '''
 module {
   func.func @myfunc() {
@@ -42,7 +42,7 @@ module {
     print(module.pretty())
 
 
-def test_trailing_loc(parser):
+def test_trailing_loc(parser: Optional[Parser] = None):
     code = '''
     module {
       func.func @myfunc() {
@@ -55,7 +55,7 @@ def test_trailing_loc(parser):
     print(module.pretty())
 
 
-def test_modules(parser):
+def test_modules(parser: Optional[Parser] = None):
     code = '''
 module {
   module {
@@ -82,7 +82,7 @@ module {
     print(module.pretty())
 
 
-def test_functions(parser):
+def test_functions(parser: Optional[Parser] = None):
     code = '''
     module {
       func.func @myfunc_a() {
@@ -99,7 +99,7 @@ def test_functions(parser):
     print(module.pretty())
 
 
-def test_toplevel_function(parser):
+def test_toplevel_function(parser: Optional[Parser] = None):
     code = '''
     func.func @toy_func(%tensor: tensor<2x3xf64>) -> tensor<3x2xf64> {
       %t_tensor = "toy.transpose"(%tensor) { inplace = true } : (tensor<2x3xf64>) -> tensor<3x2xf64>
@@ -111,7 +111,7 @@ def test_toplevel_function(parser):
     print(module.pretty())
 
 
-def test_toplevel_functions(parser):
+def test_toplevel_functions(parser: Optional[Parser] = None):
     code = '''
     func.func @toy_func(%tensor: tensor<2x3xf64>) -> tensor<3x2xf64> {
       %t_tensor = "toy.transpose"(%tensor) { inplace = true } : (tensor<2x3xf64>) -> tensor<3x2xf64>
@@ -127,7 +127,7 @@ def test_toplevel_functions(parser):
     print(module.pretty())
 
 
-def test_affine(parser):
+def test_affine(parser: Optional[Parser] = None):
     code = '''
 func.func @empty() {
   affine.for %i = 0 to 10 {
@@ -159,7 +159,7 @@ func.func @valid_symbols(%arg0: index, %arg1: index, %arg2: index) {
     print(module.pretty())
 
 
-def test_definitions(parser):
+def test_definitions(parser: Optional[Parser] = None):
     code = '''
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0) -> (d0)>
@@ -206,7 +206,7 @@ def test_definitions(parser):
     print(module.pretty())
 
 
-def test_generic_dialect_std(parser):
+def test_generic_dialect_std(parser: Optional[Parser] = None):
     code = '''
 "module"() ( {
   "func.func"() ( {
@@ -220,7 +220,7 @@ def test_generic_dialect_std(parser):
     module = parser.parse(code)
     print(module.pretty())
 
-def test_generic_dialect_std_cond_br(parser):
+def test_generic_dialect_std_cond_br(parser: Optional[Parser] = None):
     code = '''
 "module"() ( {
 "func.func"() ( {
@@ -239,7 +239,7 @@ def test_generic_dialect_std_cond_br(parser):
     module = parser.parse(code)
     print(module.pretty())
 
-def test_generic_dialect_llvm(parser):
+def test_generic_dialect_llvm(parser: Optional[Parser] = None):
     code = '''
 "module"() ( {
   "llvm.func"() ( {
@@ -254,7 +254,7 @@ def test_generic_dialect_llvm(parser):
     print(module.pretty())
 
 
-def test_generic_dialect_generic_op(parser):
+def test_generic_dialect_generic_op(parser: Optional[Parser] = None):
     code = '''
 "module"() ( {
   "func.func"() ( {
@@ -288,7 +288,7 @@ def test_generic_dialect_generic_op(parser):
     print(module.pretty())
 
 
-def test_integer_sign(parser):
+def test_integer_sign(parser: Optional[Parser] = None):
     code = '''
 func.func @integer_test(%a: si16, %b: ui32, %c: i7) {
   return

--- a/tests/test_toy.py
+++ b/tests/test_toy.py
@@ -1,25 +1,26 @@
 """ Tests pyMLIR on examples that use the Toy dialect. """
 
 from mlir import parse_string, parse_path
+from mlir.dialects.func import func 
 import os
 
 
 def test_toy_simple():
     code = '''
 module {
-  func @toy_func(%tensor: tensor<2x3xf64>) -> tensor<3x2xf64> {
+  func.func @toy_func(%tensor: tensor<2x3xf64>) -> tensor<3x2xf64> {
     %t_tensor = "toy.transpose"(%tensor) { inplace = true } : (tensor<2x3xf64>) -> tensor<3x2xf64>
     return %t_tensor : tensor<3x2xf64>
   }
 }
     '''
 
-    module = parse_string(code)
+    module = parse_string(code, dialects=[func])
     print(module.pretty())
 
 
 def test_toy_advanced():
-    module = parse_path(os.path.join(os.path.dirname(__file__), 'toy.mlir'))
+    module = parse_path(os.path.join(os.path.dirname(__file__), 'toy.mlir'), dialects=[func])
     print(module.pretty())
 
 

--- a/tests/test_toy.py
+++ b/tests/test_toy.py
@@ -15,12 +15,12 @@ module {
 }
     '''
 
-    module = parse_string(code, dialects=[func])
+    module = parse_string(code)
     print(module.pretty())
 
 
 def test_toy_advanced():
-    module = parse_path(os.path.join(os.path.dirname(__file__), 'toy.mlir'), dialects=[func])
+    module = parse_path(os.path.join(os.path.dirname(__file__), 'toy.mlir'))
     print(module.pretty())
 
 

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -47,7 +47,7 @@ module {
 '''
 
 
-def test_visitor(parser):
+def test_visitor(parser: Optional[Parser] = None):
     class MyVisitor(NodeVisitor):
         def __init__(self):
             self.functions = 0
@@ -64,7 +64,7 @@ def test_visitor(parser):
     assert visitor.functions == 3
 
 
-def test_transformer(parser):
+def test_transformer(parser: Optional[Parser] = None):
     # Simple node transformer that removes all operations with a result
     class RemoveAllResultOps(NodeTransformer):
         def visit_Operation(self, node: astnodes.Operation):

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,13 +1,19 @@
 """ Tests pyMLIR's node visitor and transformer. """
 
 from mlir import NodeVisitor, NodeTransformer, Parser, astnodes
+from mlir.dialects.func import func 
+import pytest
 from typing import Optional
+
+@pytest.fixture
+def parser(parser: Optional[Parser] = None) -> Parser:
+    return parser if parser is not None else Parser(dialects=[func])
 
 
 # Sample code to use for visitors
 _code = '''
 module {
-  func @test0(%arg0: index, %arg1: index) {
+  func.func @test0(%arg0: index, %arg1: index) {
     %0 = alloc() : memref<100x100xf32>
     %1 = alloc() : memref<100x100xf32, 2>
     %2 = alloc() : memref<1xi32>
@@ -21,7 +27,7 @@ module {
     }
     return
   }
-  func @test1(%arg0: index, %arg1: index) {
+  func.func @test1(%arg0: index, %arg1: index) {
     affine.for %arg2 = 0 to 10 {
       affine.for %arg3 = 0 to 10 {
         %c0 = constant 0 : index
@@ -34,14 +40,14 @@ module {
     }
     return
   }
-  func @test2(%arg0: index, %arg1: index) {
+  func.func @test2(%arg0: index, %arg1: index) {
     %0 = alloc() : memref<100x100xf32>
   }
 }
 '''
 
 
-def test_visitor(parser: Optional[Parser] = None):
+def test_visitor(parser):
     class MyVisitor(NodeVisitor):
         def __init__(self):
             self.functions = 0
@@ -58,7 +64,7 @@ def test_visitor(parser: Optional[Parser] = None):
     assert visitor.functions == 3
 
 
-def test_transformer(parser: Optional[Parser] = None):
+def test_transformer(parser):
     # Simple node transformer that removes all operations with a result
     class RemoveAllResultOps(NodeTransformer):
         def visit_Operation(self, node: astnodes.Operation):
@@ -90,7 +96,7 @@ def test_transformer(parser: Optional[Parser] = None):
 
 
 if __name__ == '__main__':
-    p = Parser()
+    p = Parser(dialects=[func])
     print("MLIR parser created")
     test_visitor(p)
     test_transformer(p)

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 @pytest.fixture
 def parser(parser: Optional[Parser] = None) -> Parser:
-    return parser if parser is not None else Parser(dialects=[func])
+    return parser if parser is not None else Parser()
 
 
 # Sample code to use for visitors
@@ -96,7 +96,7 @@ def test_transformer(parser):
 
 
 if __name__ == '__main__':
-    p = Parser(dialects=[func])
+    p = Parser()
     print("MLIR parser created")
     test_visitor(p)
     test_transformer(p)

--- a/tests/toy.mlir
+++ b/tests/toy.mlir
@@ -1,11 +1,11 @@
 module {
-  func @multiply_transpose(%arg0: tensor<*xf64>, %arg1: tensor<*xf64>) -> tensor<*xf64> {
+  func.func @multiply_transpose(%arg0: tensor<*xf64>, %arg1: tensor<*xf64>) -> tensor<*xf64> {
     %0 = "toy.transpose"(%arg0) : (tensor<*xf64>) -> tensor<*xf64> loc("test/codegen.toy":5:10)
     %1 = "toy.transpose"(%arg1) : (tensor<*xf64>) -> tensor<*xf64> loc("test/codegen.toy":5:25)
     %2 = "toy.mul"(%0, %1) : (tensor<*xf64>, tensor<*xf64>) -> tensor<*xf64> loc("test/codegen.toy":5:25)
     "toy.return"(%2) : (tensor<*xf64>) -> () loc("test/codegen.toy":5:3)
   } loc("test/codegen.toy":4:1)
-  func @main() {
+  func.func @main() {
     %0 = "toy.constant"() {value = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64> loc("test/codegen.toy":9:17)
     %1 = "toy.reshape"(%0) : (tensor<2x3xf64>) -> tensor<2x3xf64> loc("test/codegen.toy":9:3)
     %2 = "toy.constant"() {value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00]> : tensor<6xf64>} : () -> tensor<6xf64> loc("test/codegen.toy":10:17)
@@ -16,7 +16,7 @@ module {
     "toy.return"() : () -> () loc("test/codegen.toy":8:1)
   } loc("test/codegen.toy":8:1)
   
-func @main() {
+func.func @main() {
   %cst = constant 1.000000e+00 : f64
   %cst_0 = constant 2.000000e+00 : f64
   %cst_1 = constant 3.000000e+00 : f64
@@ -64,7 +64,7 @@ func @main() {
   return
 }
 
-func @main() {
+func.func @main() {
   %cst = constant 1.000000e+00 : f64
   %cst_0 = constant 2.000000e+00 : f64
   %cst_1 = constant 3.000000e+00 : f64
@@ -104,7 +104,7 @@ func @main() {
 } loc("test/codegen.toy":0:0)
 
 module {
-  func @multiply_transpose(%arg0: !toy.struct<tensor<*xf64>, tensor<*xf64>>) {
+  func.func @multiply_transpose(%arg0: !toy.struct<tensor<*xf64>, tensor<*xf64>>) {
     "toy.return"() : () -> ()
   }
 }


### PR DESCRIPTION
Fix for issues #19 and #21.

#19:
In the latest versions of MLIR, the `func`, `call` and `return` operators have been refactored into a new [dialect](https://mlir.llvm.org/docs/Dialects/Func/) called `func`. MLIR now only recognizes the syntax `func.func` for what was previously called the `func` operation. This PR refactors pymlir to have a `func` dialect, prepending "func" to the requisite ops (except for `return`, which somehow still retains its bare form).

Existing tests have been refactored to use the `func` dialect where applicable. Also, the parser is now initialized with a pytest fixture where applicable.

#21:
Fix emitted code for `func.func ()`. Add a unit test in `test_roundtrip.py` to cover this. 