### PR TITLE
Update linalg.generic syntax

### DIFF
--- a/mlir/dialects/linalg.py
+++ b/mlir/dialects/linalg.py
@@ -144,6 +144,10 @@ class LinalgGeneric(DialectOp):
                  " {region.region}"),
                 ("linalg.generic {attr.attribute_value} "
                  " ins( {inargs.ssa_id_list} : {in_types.type_list_no_parens} )"
+                 " outs( {outargs.ssa_id_list} : {out_types.type_list_no_parens} )"
+                 " {region.region} -> {out_type.type}"),
+                ("linalg.generic {attr.attribute_value} "
+                 " ins( {inargs.ssa_id_list} : {in_types.type_list_no_parens} )"
                  " init( {init_args.ssa_id_list} : {init_types.type_list_no_parens} )"
                  " {region.region} -> {out_type.type}")]
 


### PR DESCRIPTION
Adding an additional syntax for the linalg.generic op as per the last example in the [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalggeneric-linalggenericop).