### PR TITLE
Fix 'float_type' assertion error

### DIFF
--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -126,7 +126,7 @@ class FloatTypeEnum(Enum):
 
 @dataclass
 class FloatType(Type):
-    type: str
+    type: FloatTypeEnum
 
     def dump(self, indent: int = 0) -> str:
         return self.type.name

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -126,7 +126,7 @@ class FloatTypeEnum(Enum):
 
 @dataclass
 class FloatType(Type):
-    type: FloatTypeEnum
+    type: str
 
     def dump(self, indent: int = 0) -> str:
         return self.type.name

--- a/mlir/parser_transformer.py
+++ b/mlir/parser_transformer.py
@@ -63,7 +63,7 @@ class TreeToMlir(Transformer):
     BF16 = lambda self, tok: astnodes.FloatTypeEnum("bf16")
     F32 = lambda self, tok: astnodes.FloatTypeEnum("f32")
     F64 = lambda self, tok: astnodes.FloatTypeEnum("f64")
-    float_type = lambda self, tok: astnodes.FloatType(tok[0].value)
+    float_type = lambda self, tok: astnodes.FloatType(astnodes.FloatTypeEnum(tok[0].value))
     index_type = astnodes.IndexType.from_lark
     signed_integer_type = astnodes.SignedIntegerType.from_lark
     unsigned_integer_type = astnodes.UnsignedIntegerType.from_lark

--- a/mlir/parser_transformer.py
+++ b/mlir/parser_transformer.py
@@ -63,7 +63,7 @@ class TreeToMlir(Transformer):
     BF16 = lambda self, tok: astnodes.FloatTypeEnum("bf16")
     F32 = lambda self, tok: astnodes.FloatTypeEnum("f32")
     F64 = lambda self, tok: astnodes.FloatTypeEnum("f64")
-    float_type = astnodes.FloatType.from_lark
+    float_type = lambda self, tok: astnodes.FloatType(tok[0].value)
     index_type = astnodes.IndexType.from_lark
     signed_integer_type = astnodes.SignedIntegerType.from_lark
     unsigned_integer_type = astnodes.UnsignedIntegerType.from_lark


### PR DESCRIPTION
This PR fixes https://github.com/spcl/pymlir/issues/24, which is the assertion error encountered when transforming `float_type`.

Instead of using the `from_lark` method to construct a `FloatType` instance with unaltered args, this change uses a lambda function to call the `FloatType` constructor with the value of the Token rather than the Token itself.