### PR TITLE
Minor LARK changes

### DIFF
--- a/mlir/dialect.py
+++ b/mlir/dialect.py
@@ -79,8 +79,8 @@ class DialectElement(astnodes.Node):
             for fname, ftype in sfields:
                 syntax = syntax.replace('{%s.%s}' % (fname, ftype), ftype)
             # Replace back braces
-            syntax = syntax.replace('{LBRACE}', '{')
-            syntax = syntax.replace('{RBRACE}', '}')
+            syntax = syntax.replace('{LBRACE}', '"{"')
+            syntax = syntax.replace('{RBRACE}', '"}"')
             lark_exprs.append(syntax)
 
         cls._fields_ = list(fields)

--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -27,7 +27,7 @@ constant_literal : bool_literal | integer_literal | float_literal | string_liter
 
 // Identifier syntax
 bare_id : (letter| underscore) (letter|digit|underscore|id_chars)*
-suffix_id : digits | bare_id
+suffix_id : digits | ((letter | id_punct) (letter | id_punct | digits)*)
 
 // Dimensions
 dimension : "?" | decimal_literal

--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -335,5 +335,5 @@ mlir_file: definition_and_function_list*       -> only_functions_and_definitions
 // Things to ignore: whitespace, single-line comments
 %ignore WS
 
-COMMENT : "//" /(.)+/ NEWLINE
+COMMENT : "//" /(.)*/ NEWLINE
 %ignore COMMENT


### PR DESCRIPTION
- Wrap escaped curly braces in __syntax__ so LARK recognizes them as terminals
- suffix_id should also include dashes (use id_punct rule). See [lang ref](https://mlir.llvm.org/docs/LangRef/#identifiers-and-keywords) for details
- "//" with no trailing whitespace or characters should also be considered a comment